### PR TITLE
Update for stable rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,33 +1,186 @@
-[root]
-name = "beanstalkd-cli"
-version = "0.3.0"
+[[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "beanstalkd 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "docopt 0.6.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "beanstalkd"
 version = "0.3.2"
+source = "git+https://github.com/schickling/rust-beanstalkd.git#f16baeb1e276de315b9349e002237d2fd77b7257"
+dependencies = [
+ "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "beanstalkd-cli"
+version = "0.4.0"
+dependencies = [
+ "beanstalkd 0.3.2 (git+https://github.com/schickling/rust-beanstalkd.git)",
+ "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "bufstream"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "docopt"
-version = "0.6.39"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libc"
+version = "0.2.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.1.15"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.2.15"
+name = "serde_derive"
+version = "1.0.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "strsim"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "syn"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum beanstalkd 0.3.2 (git+https://github.com/schickling/rust-beanstalkd.git)" = "<none>"
+"checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
+"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
+"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
+"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "428d3d818cb94ee037a17bf4f2200db2552e19b1825d33df2196624290716f92"
+"checksum serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "ee76093b16868c4c9c8e5329c3d30745833e35390624019738472bd13e996e79"
+"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,8 +8,8 @@ dependencies = [
 
 [[package]]
 name = "beanstalkd"
-version = "0.3.2"
-source = "git+https://github.com/schickling/rust-beanstalkd.git#f16baeb1e276de315b9349e002237d2fd77b7257"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -18,8 +18,8 @@ dependencies = [
 name = "beanstalkd-cli"
 version = "0.4.0"
 dependencies = [
- "beanstalkd 0.3.2 (git+https://github.com/schickling/rust-beanstalkd.git)",
- "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "beanstalkd 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "docopt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -31,14 +31,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "docopt"
-version = "0.8.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -77,19 +77,19 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.11"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -164,19 +164,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
-"checksum beanstalkd 0.3.2 (git+https://github.com/schickling/rust-beanstalkd.git)" = "<none>"
+"checksum beanstalkd 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "306bf45a74737ad160c217724e32e8c49d187cdeaab65cd9ba097adcdb5b5b85"
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
-"checksum docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d8acd393692c503b168471874953a2531df0e9ab77d0b6bbc582395743300a4a"
+"checksum docopt 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e67fb750c36fc6fffbd3575cf8f2b46790fc0b05096ae3c03a36cf71b55e1e2b"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
+"checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
+"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum serde 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "428d3d818cb94ee037a17bf4f2200db2552e19b1825d33df2196624290716f92"
 "checksum serde_derive 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "ee76093b16868c4c9c8e5329c3d30745833e35390624019738472bd13e996e79"
-"checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "beanstalkd-cli"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Johannes Schickling <schickling.j@gmail.com>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/schickling/beanstalkd-cli"
@@ -12,6 +12,7 @@ readme = "README.md"
 
 [dependencies]
 
-beanstalkd = "*"
+beanstalkd = { version = "*", git = "https://github.com/schickling/rust-beanstalkd.git" }
 docopt = "*"
-rustc-serialize = "*"
+serde = "1.0"
+serde_derive = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 
-beanstalkd = { version = "*", git = "https://github.com/schickling/rust-beanstalkd.git" }
-docopt = "*"
+beanstalkd = "0.4"
+docopt = "1.0"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -1,26 +1,27 @@
-use std::old_io::stdio::flush;
-use std::old_io::timer::sleep;
-use std::time::duration::Duration;
+use std::thread::sleep;
+use std::time::Duration;
+use std::io::{self, Write};
 
 use beanstalkd::Beanstalkd;
 
 pub fn monitor(beanstalkd: &mut Beanstalkd) {
-    let one_sec = Duration::seconds(1);
+    let one_sec = Duration::from_secs(1);
     let interesting_keys = vec!("current-jobs-ready",
                                 "current-workers",
                                 "current-producers",
                                 "current-connections");
     let mut length = 0;
+    let mut stdout = io::stdout();
     loop {
         let stats = beanstalkd.stats().unwrap();
-        let mut string = range(0, length).fold(String::new(), |s, _| s + "\x08");
+        let mut string = (0..length).fold(String::new(), |s, _| s + "\x08");
         for key in interesting_keys.iter() {
             string = format!("{}{}: {}, ", string, key, stats.get(&key.to_string()).unwrap());;
         }
         length = string.len() - 2;
         string.truncate(length);
-        print!("{}", string);
-        flush();
+        write!(stdout, "{}", string).expect("error writing to stdout");
+        let _ = stdout.flush();
         sleep(one_sec);
     }
 }

--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -6,17 +6,24 @@ use beanstalkd::Beanstalkd;
 
 pub fn monitor(beanstalkd: &mut Beanstalkd) {
     let one_sec = Duration::from_secs(1);
-    let interesting_keys = vec!("current-jobs-ready",
-                                "current-workers",
-                                "current-producers",
-                                "current-connections");
+    let interesting_keys = vec![
+        "current-jobs-ready",
+        "current-workers",
+        "current-producers",
+        "current-connections",
+    ];
     let mut length = 0;
     let mut stdout = io::stdout();
     loop {
         let stats = beanstalkd.stats().unwrap();
         let mut string = (0..length).fold(String::new(), |s, _| s + "\x08");
         for key in interesting_keys.iter() {
-            string = format!("{}{}: {}, ", string, key, stats.get(&key.to_string()).unwrap());;
+            string = format!(
+                "{}{}: {}, ",
+                string,
+                key,
+                stats.get(&key.to_string()).unwrap()
+            );;
         }
         length = string.len() - 2;
         string.truncate(length);

--- a/src/commands/put.rs
+++ b/src/commands/put.rs
@@ -1,5 +1,5 @@
 use beanstalkd::Beanstalkd;
 
 pub fn put(beanstalkd: &mut Beanstalkd, message: String) {
-    let _ = beanstalkd.put(message.as_slice(), 0, 0, 10000);
+    let _ = beanstalkd.put(&message, 0, 0, 10000);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-extern crate docopt;
 extern crate beanstalkd;
+extern crate docopt;
 #[macro_use]
 extern crate serde_derive;
 
@@ -46,15 +46,17 @@ struct Args {
 
 fn main() {
     let args: Args = Docopt::new(USAGE)
-                            .and_then(|d| d.version(Some(VERSION.to_string())).deserialize())
-                            .unwrap_or_else(|e| e.exit());
+        .and_then(|d| d.version(Some(VERSION.to_string())).deserialize())
+        .unwrap_or_else(|e| e.exit());
 
-    if ! (args.cmd_put || args.cmd_pop || args.cmd_monitor || args.cmd_stats) {
+    if !(args.cmd_put || args.cmd_pop || args.cmd_monitor || args.cmd_stats) {
         println!("{}", USAGE.trim());
         return;
     }
 
-    let mut beanstalkd = Beanstalkd::connect(&args.flag_host, args.flag_port).ok().expect("Server not running");
+    let mut beanstalkd = Beanstalkd::connect(&args.flag_host, args.flag_port)
+        .ok()
+        .expect("Server not running");
 
     if args.cmd_put {
         commands::put::put(&mut beanstalkd, args.arg_message);


### PR DESCRIPTION
This PR makes changes to get beanstalkd-cli build on current stable rust (1.25.0):

- Remove feature flags
- Update `rust-beanstalkd` to version that complies on current Rust. Unfortunately there hasn't been a release to crates.io with the fixes, so it's a git dependency. See https://github.com/schickling/rust-beanstalkd/issues/4
- Update docopt and replace `rustc-serialize` with `serde`
- Replace use of `as_slice` with references
- Use new `io` functions
- Use new sleep/Duration API

I took the liberty of running `rustfmt` on the code as well. That's in a separate commit so can easily be removed if you'd prefer.

I haven't done extensive testing but I was able to `put`, `pop`, and get `stats`.