### PR TITLE
Allow selection of tube(s) for pop/put

### DIFF
--- a/src/commands/pop.rs
+++ b/src/commands/pop.rs
@@ -1,6 +1,12 @@
 use beanstalkd::Beanstalkd;
 
-pub fn pop(beanstalkd: &mut Beanstalkd) {
+pub fn pop(beanstalkd: &mut Beanstalkd, tubes: Vec<&str>) {
+    if !(tubes.len() == 1 && tubes[0] == "default") {
+        let _ = beanstalkd.ignore("default");
+        for tube in tubes {
+            let _ = beanstalkd.watch(tube);
+        }
+    }
     let (id, message) = beanstalkd.reserve().unwrap();
     println!("{}", message);
     let _ = beanstalkd.delete(id);

--- a/src/commands/put.rs
+++ b/src/commands/put.rs
@@ -1,5 +1,8 @@
 use beanstalkd::Beanstalkd;
 
-pub fn put(beanstalkd: &mut Beanstalkd, message: String) {
+pub fn put(beanstalkd: &mut Beanstalkd, message: String, tube: &str) {
+    if tube != "default" {
+        let _ = beanstalkd.tube(tube);
+    }
     let _ = beanstalkd.put(&message, 0, 0, 10000);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ Commands:
 Options:
     -h, --host=<host>  Hostname of the beanstalkd server [default: localhost]
     -p, --port=<port>  Port of the beanstalkd server [default: 11300]
+    -t, --tube=<tube>  Tube to put/pop from - pop can use multiple tubes comma separated
     --help             Display this message
     -v, --version      Print version info and exit
 ";
@@ -36,6 +37,7 @@ Options:
 struct Args {
     flag_host: String,
     flag_port: u16,
+    flag_tube: String,
     cmd_put: bool,
     arg_message: String,
     cmd_pop: bool,
@@ -58,10 +60,16 @@ fn main() {
         .ok()
         .expect("Server not running");
 
+    let mut tubes: Vec<&str> = vec!["default"];
+
+    if !args.flag_tube.is_empty() {
+        tubes = args.flag_tube.split(",").collect();
+    }
+
     if args.cmd_put {
-        commands::put::put(&mut beanstalkd, args.arg_message);
+        commands::put::put(&mut beanstalkd, args.arg_message, tubes[0]);
     } else if args.cmd_pop {
-        commands::pop::pop(&mut beanstalkd);
+        commands::pop::pop(&mut beanstalkd, tubes);
     } else if args.cmd_monitor {
         commands::monitor::monitor(&mut beanstalkd);
     } else if args.cmd_stats {


### PR DESCRIPTION
This fixes #2.

Allows multiple tubes for pops and takes the first one provided for puts.