### PR TITLE
Remove warning for double semicolons ;;

### DIFF
--- a/src/commands/monitor.rs
+++ b/src/commands/monitor.rs
@@ -23,7 +23,7 @@ pub fn monitor(beanstalkd: &mut Beanstalkd) {
                 string,
                 key,
                 stats.get(&key.to_string()).unwrap()
-            );;
+            );
         }
         length = string.len() - 2;
         string.truncate(length);


### PR DESCRIPTION
```
warning: unnecessary trailing semicolon
  --> src/commands/monitor.rs:26:15
   |
26 |             );;
   |               ^ help: remove this semicolon
   |
   = note: `#[warn(redundant_semicolons)]` on by default

warning: `beanstalkd-cli` (bin "beanstalkd-cli") generated 1 warning
    Finished dev [unoptimized + debuginfo] target(s) in 45.32s
```